### PR TITLE
CI を回しましょう

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: cpp
+compiler:
+    - clang
+    - gcc
+dist: xenial
+addons:
+    apt:
+        packages:
+            - python3
+            - python3-pip
+            - python3-setuptools
+
+before_install:
+    - pip3 install -U setuptools
+    - pip3 install -U online-judge-tools==6
+script:
+    - ./test.sh

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # library
+
+[![Travis](https://img.shields.io/travis/beet-aizu/library/master.svg)](https://travis-ci.org/beet-aizu/library)
+
 うぃーんﾋﾞｰﾄﾋﾞｰﾄひるどwwwwwwうっくっくwwwwwwえいえいえt(←いずらいt)いえいwwwwらて。

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# install: pip3 install online-judge-tools==6
+set -e
+which oj > /dev/null
+
+CXX=${CXX:-g++}
+CXXFLAGS="${CXXFLANGS:--std=c++14 -O2 -Wall -g}"
+
+run() {
+    file="$1"
+    url="$(grep -o '^# *define \+PROBLEM \(https\?://.*\)' < "$file" | sed 's/.* http/http/')"
+    dir=test/$(echo -n "$url" | md5sum | sed 's/ .*//')
+    mkdir -p ${dir}
+    $CXX $CXXFLAGS -I . -o ${dir}/a.out "$file"
+    if [[ -n ${url} ]] ; then
+        if [[ ! -e ${dir}/test ]] ; then
+            sleep 2
+            oj download --system "$url" -d ${dir}/test
+        fi
+        oj test -c ${dir}/a.out -d ${dir}/test
+    else
+        ${dir}/a.out
+    fi
+}
+
+if [ $# -eq 0 ] ; then
+    for f in $(find . -name \*.test.cpp) ; do
+        run $f
+    done
+else
+    for f in "$@" ; do
+        run "$f"
+    done
+fi


### PR DESCRIPTION
テストを自動化します。
これをマージして https://travis-ci.org/ から設定すれば、push するたびにテストがいい感じになります (例: https://travis-ci.org/kmyk/competitive-programming-library )。

`.test.cpp` という形のファイルを置いておくと自動でコンパイルして自動で実行してくれます。
`#define PROBLEM https://...` みたいな形で URL を書いておくと、指定された問題のテストケースを取得して勝手にテストしてくれます (例: https://github.com/kmyk/competitive-programming-library/blob/master/data_structure/union_find_tree.test.cpp )。ただし AtCoder は未対応 (内部のテストケースをちゃんと公開してくれてないので) で、ほぼ AOJ 専用です。 