### PR TITLE
enable to use GCC_ONLY flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: cpp
 compiler:
     - gcc
+    - clang
 dist: xenial
 addons:
     apt:

--- a/test.sh
+++ b/test.sh
@@ -11,6 +11,9 @@ run() {
     url="$(grep -o '^# *define \+PROBLEM \(https\?://.*\)' < "$file" | sed 's/.* http/http/')"
     dir=test/$(echo -n "$url" | md5sum | sed 's/ .*//')
     mkdir -p ${dir}
+    if [[ $CXX =~ clang ]] && grep '^# *define \+GCC_ONLY\>' < "$file" > /dev/null ; then
+        return
+    fi
     $CXX $CXXFLAGS -I . -o ${dir}/a.out "$file"
     if [[ -n ${url} ]] ; then
         if [[ ! -e ${dir}/test ]] ; then


### PR DESCRIPTION
GCC 拡張は便利ですが、複数のコンパイラで動作確認することも重要です。本来は未定義動作だけど処理系によっては動いてしまう書き方 (たとえば `std::map` に対する `f[n] = f.size();` とか) があるためです。

このプルリクは `test.sh` を修正し、`.test.cpp` 内に `#define GCC_ONLY` という文字列があれば clang でのテストをスキップするようにします。