### PR TITLE
fix the version of online-judge-tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ addons:
 
 before_install:
     - pip3 install -U setuptools
-    - pip3 install -U online-judge-tools==6
+    - pip3 install -U online-judge-tools=='6.*'
 script:
     - ./test/test.sh


### PR DESCRIPTION
これ https://twitter.com/beet_aizu/status/1159008831256399872 を解決します。

バージョンを `==6` って指定したらバージョン `6.y.z` の最新のものが入ると思いませんか？ そうではありませんでした。