### PR TITLE
add ulimit -s unlimited

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -5,6 +5,7 @@ which oj > /dev/null
 
 CXX=${CXX:-g++}
 CXXFLAGS="${CXXFLANGS:--std=c++14 -O2 -Wall -g}"
+ulimit -s unlimited
 
 run() {
     file="$1"


### PR DESCRIPTION
stack の大きさの問題で落ちるやつが発生するぽい (https://github.com/beet-aizu/library/blob/master/test/aoj/2450.test.cpp) 。これは `ulimit -s unlimited` しておけば解決します。