### PR TITLE
update test.sh

### DIFF
--- a/test/aoj/2450.test.cpp
+++ b/test/aoj/2450.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=2450
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=2450"
 
 #define main moin
 #define SegmentTree SegmentUkunichiakun

--- a/test/aoj/2488.test.cpp
+++ b/test/aoj/2488.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=2488
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=2488"
 #define main moin
 #include "../../algorithm/knuthyao.cpp"
 #undef main

--- a/test/aoj/2667.test.cpp
+++ b/test/aoj/2667.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=2667
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=2667"
 
 #define main moin
 #define SegmentTree SegmentUkunichiakun

--- a/test/aoj/DPL_3_C.test.cpp
+++ b/test/aoj/DPL_3_C.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_3_C
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_3_C"
 #define main moin
 #include "../../algorithm/largestrectangle.cpp"
 #undef main

--- a/test/aoj/DPL_5_A.test.cpp
+++ b/test/aoj/DPL_5_A.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_A
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_A"
 #define main moin
 #include "../../mod/enumeration.cpp"
 #undef main

--- a/test/aoj/DPL_5_B.test.cpp
+++ b/test/aoj/DPL_5_B.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_B
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_B"
 #define main moin
 #include "../../mod/enumeration.cpp"
 #undef main

--- a/test/aoj/DPL_5_C.test.cpp
+++ b/test/aoj/DPL_5_C.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_C
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_C"
 #define main moin
 #include "../../mod/enumeration.cpp"
 #undef main

--- a/test/aoj/DPL_5_D.test.cpp
+++ b/test/aoj/DPL_5_D.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_D
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_D"
 #define main moin
 #include "../../mod/enumeration.cpp"
 #undef main

--- a/test/aoj/DPL_5_E.test.cpp
+++ b/test/aoj/DPL_5_E.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_E
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_E"
 #define main moin
 #include "../../mod/enumeration.cpp"
 #undef main

--- a/test/aoj/DPL_5_F.test.cpp
+++ b/test/aoj/DPL_5_F.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_F
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_F"
 #define main moin
 #include "../../mod/enumeration.cpp"
 #undef main

--- a/test/aoj/DPL_5_G.test.cpp
+++ b/test/aoj/DPL_5_G.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_G
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_G"
 #define main moin
 #include "../../mod/enumeration.cpp"
 #undef main

--- a/test/aoj/DPL_5_H.test.cpp
+++ b/test/aoj/DPL_5_H.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_H
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_H"
 #define main moin
 #include "../../mod/enumeration.cpp"
 #undef main

--- a/test/aoj/DPL_5_I.test.cpp
+++ b/test/aoj/DPL_5_I.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_I
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_I"
 #define main moin
 #include "../../mod/enumeration.cpp"
 #undef main

--- a/test/aoj/DPL_5_J.test.cpp
+++ b/test/aoj/DPL_5_J.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_J
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_J"
 #define main moin
 #include "../../mod/enumeration.cpp"
 #undef main

--- a/test/aoj/DPL_5_K.test.cpp
+++ b/test/aoj/DPL_5_K.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_K
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_K"
 #define main moin
 #include "../../mod/enumeration.cpp"
 #undef main

--- a/test/aoj/DPL_5_L.test.cpp
+++ b/test/aoj/DPL_5_L.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_L
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DPL_5_L"
 #define main moin
 #include "../../mod/enumeration.cpp"
 #undef main

--- a/test/aoj/GRL_5_C.test.cpp
+++ b/test/aoj/GRL_5_C.test.cpp
@@ -1,4 +1,4 @@
-#define PROBLEM http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=GRL_5_C
+#define PROBLEM "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=GRL_5_C"
 #define main moin
 #include "../../tree/heavylightdecomposition.cpp"
 #undef main

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,37 +1,97 @@
 #!/bin/bash
-# install: pip3 install online-judge-tools==6
 set -e
+
+# you can install oj with: $ pip3 install --user -U online-judge-tools=='6.*'
 which oj > /dev/null
 
 CXX=${CXX:-g++}
 CXXFLAGS="${CXXFLAGS:--std=c++14 -O2 -Wall -g}"
 ulimit -s unlimited
 
+
+list-dependencies() {
+    file="$1"
+    $CXX $CXXFLAGS -I . -MD -MF /dev/stdout -MM "$file" | sed '1s/[^:].*: // ; s/\\$//' | xargs -n 1
+}
+
+list-defined() {
+    file="$1"
+    $CXX $CXXFLAGS -I . -dM -E "$file"
+}
+
+get-url() {
+    file="$1"
+    list-defined "$file" | grep '^#define PROBLEM ' | sed 's/^#define PROBLEM "\(.*\)"$/\1/'
+}
+
+is-verified() {
+    file="$1"
+    cache=test/timestamp/$(echo -n "$file" | md5sum | sed 's/ .*//')
+    timestamp="$(list-dependencies "$file" | xargs -I '{}' find "$file" '{}' -printf "%T+\t%p\n" | sort -nr | head -n 1 | cut -f 2)"
+    [[ -e $cache ]] && [[ $timestamp -ot $cache ]]
+}
+
+mark-verified() {
+    file="$1"
+    cache=test/timestamp/$(echo -n "$file" | md5sum | sed 's/ .*//')
+    mkdir -p test/timestamp
+    touch $cache
+}
+
+list-recently-updated() {
+    for file in $(find . -name \*.test.cpp) ; do
+        list-dependencies "$file" | xargs -n 1 | while read f ; do
+            git log -1 --format="%ci	${file}" "$f"
+        done | sort -nr | head -n 1
+    done | sort -nr | head -n 20 | cut -f 2
+}
+
 run() {
     file="$1"
-    url="$(grep -o '^# *define \+PROBLEM \(https\?://.*\)' < "$file" | sed 's/.* http/http/')"
+    url="$(get-url "$file")"
     dir=test/$(echo -n "$url" | md5sum | sed 's/ .*//')
     mkdir -p ${dir}
-    if [[ $CXX =~ clang ]] && grep '^# *define \+GCC_ONLY\>' < "$file" > /dev/null ; then
+
+    # ignore if IGNORE is defined
+    if list-defined "$file" | grep '^#define IGNORE ' > /dev/null ; then
         return
     fi
-    $CXX $CXXFLAGS -I . -o ${dir}/a.out "$file"
-    if [[ -n ${url} ]] ; then
-        if [[ ! -e ${dir}/test ]] ; then
-            sleep 2
-            oj download --system "$url" -d ${dir}/test
+
+    if ! is-verified "$file" ; then
+        # compile
+        $CXX $CXXFLAGS -I . -o ${dir}/a.out "$file"
+        if [[ -n ${url} ]] ; then
+            # download
+            if [[ ! -e ${dir}/test ]] ; then
+                sleep 2
+                oj download --system "$url" -d ${dir}/test
+            fi
+            # test
+            oj test -c ${dir}/a.out -d ${dir}/test
+        else
+            # run
+            ${dir}/a.out
         fi
-        oj test -c ${dir}/a.out -d ${dir}/test
-    else
-        ${dir}/a.out
+        mark-verified "$file"
     fi
 }
 
-if [ $# -eq 0 ] ; then
-    for f in $(find . -name \*.test.cpp) ; do
-        run $f
-    done
+
+if [[ $# -eq 0 ]] ; then
+    if [[ $CI ]] ; then
+        # CI
+        for f in $(list-recently-updated) ; do
+            run $f
+        done
+
+    else
+        # local
+        for f in $(find . -name \*.test.cpp) ; do
+            run $f
+        done
+    fi
 else
+    # specified
     for f in "$@" ; do
         run "$f"
     done


### PR DESCRIPTION
include の依存関係を解析し、差分だけテストするようにしました。
CI 上では同様に依存関係を解析して、最近変更のあったファイルに依存するような上位 20 ファイルだけをテストします。テストが無限に増えてもたぶん大丈夫です。

ちゃんとプリプロセッサの解析をするようになり、 clang では実行してほしくない場合は以下のように書くこととなりました。`IGNORE` が定義されていると無視されます。

``` c++
#ifdef __clang__
#define IGNORE
#endif
```