### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # library
 
 [![Actions Status](https://github.com/beet-aizu/library/workflows/verify/badge.svg)](https://github.com/beet-aizu/library/actions)
-
-[Verification Status](https://beet-aizu.github.io/library/)
+[![GitHub Pages](https://img.shields.io/static/v1?label=GitHub+Pages&message=+&color=brightgreen&logo=github)](https://beet-aizu.github.io/library/)
 
 うぃーんﾋﾞｰﾄﾋﾞｰﾄひるどwwwwwwうっくっくwwwwwwえいえいえt(←いずらいt)いえいwwwwらて。
 


### PR DESCRIPTION
GitHub Pages に飛ぶリンクですが、こっちの方が分かりやすいので置き換え

加えて、リポジトリのトップページの上の方にある説明部分にURLを書く場所がありますが、そこにも https://beet-aizu.github.io/library/ のURLを書いておいてほしいです。よろしくお願いします